### PR TITLE
Fix Global Variables not initialized yet exception

### DIFF
--- a/cs2-tags/src/api/api.cs
+++ b/cs2-tags/src/api/api.cs
@@ -262,7 +262,7 @@ public class TagsAPI : ITagApi
     public void ReloadTags()
     {
         Instance.Config.Reload();
-        UpdateConfig(Instance.Config);
+        UpdateConfig(Instance.Config, true);
     }
 
     public void SetExternalTag(CCSPlayerController player, TagType types, string newValue, bool persistent = true)

--- a/cs2-tags/src/cs2-tag.cs
+++ b/cs2-tags/src/cs2-tag.cs
@@ -59,9 +59,13 @@ public class Tags : BasePlugin, IPluginConfig<Config>
         }
     }
 
+    public void OnMapStart(string mapName)
+    {
+        UpdateConfig(Config);
+    }
+
     public void OnConfigParsed(Config config)
     {
-        UpdateConfig(config);
         Config = config;
     }
 


### PR DESCRIPTION
This PR resolves the Global Variables not initialized yet exception caused by premature access to game state during plugin load.
Changes:
  [Critical Fix]
    1. Moved player data loading operations from UpdateConfig() to the OnMapStart lifecycle hook
    2. Ensures Utilities.GetPlayers() is only called after global variables are fully initialized

Fixed the error below: 

> 01:18:55 [EROR] (cssharp:PluginManager) Failed to load plugin from E:\steam\steamapps\common\Counter-Strike Global Offensive\game\csgo\addons\counterstrikesharp\plugins\cs2-tags\cs2-tags.dll
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> CounterStrikeSharp.API.Core.NativeException: Global Variables not initialized yet.
   at CounterStrikeSharp.API.Core.ScriptContext.CheckErrors() in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/ScriptContext.cs:line 187
   at CounterStrikeSharp.API.Core.NativeAPI.GetMaxClients() in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/API.cs:line 347
   at CounterStrikeSharp.API.Server.get_MaxPlayers() in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Server.cs:line 145
   at CounterStrikeSharp.API.Utilities.GetPlayers() in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Utilities.cs:line 153
   at Tags.Tags.UpdateConfig(Config config) in /home/runner/work/cs2-tags/cs2-tags/cs2-tags/src/cs2-tag.cs:line 96
   at Tags.Tags.OnConfigParsed(Config config) in /home/runner/work/cs2-tags/cs2-tags/cs2-tags/src/cs2-tag.cs:line 64
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span1 copyOfArgs, BindingFlags invokeAttr)
   at System.Reflection.MethodBaseInvoker.InvokeWithOneArg(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at CounterStrikeSharp.API.Core.BasePlugin.InitializeConfig(Object instance, Type pluginType) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/BasePlugin.cs:line 393
   at CounterStrikeSharp.API.Core.Plugin.PluginContext.Load(Boolean hotReload) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Plugin/PluginContext.cs:line 217
   at CounterStrikeSharp.API.Core.Plugin.Host.PluginManager.LoadPlugin(String path) in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginManager.cs:line 125
   at CounterStrikeSharp.API.Core.Plugin.Host.PluginManager.Load() in /home/runner/work/CounterStrikeSharp/CounterStrikeSharp/managed/CounterStrikeSharp.API/Core/Plugin/Host/PluginManager.cs:line 93